### PR TITLE
fix(): wrong color on autofill with light theme

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -34,3 +34,7 @@
 input:-webkit-autofill { 
   -webkit-background-clip: text;
 }
+
+input[type=email]:-webkit-autofill {
+  -webkit-text-fill-color: white
+}


### PR DESCRIPTION
<img width="1294" alt="Captura de Pantalla 2023-06-15 a las 0 11 41" src="https://github.com/midudev/noticias.dev/assets/12160420/db91dfa1-0db8-44f3-b735-2fbf1188d493">

Visual Error.

When you enter the email with the autocomplete, it appears in a colour that is indistinguishable from the background. 

I have put the fix for that specific input (email) type and with the colour you have in the class itself (text-white). 

