### PR TITLE
feat: Open links in new tab/page & feat(tailwind): Sticky dates on XL resolutions

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -68,7 +68,7 @@ function Glow() {
 
 function FixedSidebar({ main, footer }) {
   return (
-    <div className="relative flex-none overflow-hidden px-6 lg:pointer-events-none lg:fixed lg:inset-0 lg:z-40 lg:flex lg:px-0">
+    <div className="relative flex-none overflow-hidden px-6 lg:pointer-events-none lg:fixed lg:inset-0 lg:z-40 xl:z-0 lg:flex lg:px-0 ">
       <Glow />
       <div className="relative flex w-full lg:pointer-events-auto lg:mr-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] lg:overflow-y-auto lg:pl-[max(4rem,calc(50%-38rem))]">
         <div className="mx-auto max-w-lg lg:mx-0 lg:flex lg:w-96 lg:max-w-none lg:flex-col lg:before:flex-1 lg:before:pt-6">

--- a/src/components/mdx.jsx
+++ b/src/components/mdx.jsx
@@ -52,7 +52,7 @@ function ContentWrapper({ className, children }) {
 
 function ArticleHeader({ id, date }) {
   return (
-    <header className="relative mb-10 xl:mb-0">
+    <header className="relative xl:sticky xl:top-1 mb-10 xl:mb-0">
       <div className="pointer-events-none absolute left-[max(-0.5rem,calc(50%-18.625rem))] top-0 z-50 flex h-4 items-center justify-end gap-x-2 lg:left-0 lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] xl:h-8">
         <Link href={`#${id}`} className="inline-flex">
           <FormattedDate

--- a/src/hooks/useOpenAllLinksInNewTab.js
+++ b/src/hooks/useOpenAllLinksInNewTab.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export const useOpenAllLinksInNewTab = () => {
+  useEffect(() => {
+    const handleClick = (event) => {
+      if (event.target.tagName === 'A') {
+        event.preventDefault();
+        window.open(event.target.href, '_blank');
+      }
+    };
+
+    window.addEventListener('click', handleClick);
+
+    return () => {
+      window.removeEventListener('click', handleClick);
+    };
+  }, []);
+};

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -4,11 +4,15 @@ import { MDXProvider } from '@mdx-js/react'
 
 import { Layout } from '@/components/Layout'
 import * as mdxComponents from '@/components/mdx'
+import {useOpenAllLinksInNewTab} from "@/hooks/useOpenAllLinksInNewTab";
 
 import '@/styles/tailwind.css'
 import 'focus-visible'
 
+
 export default function App({ Component, pageProps }) {
+  useOpenAllLinksInNewTab();
+
   return (
     <>
       <Head>


### PR DESCRIPTION
Changelog:

1. Open links in a new tab/page to avoid navigating out from the web app if the user clicks on any link. Closes #2

2. Minor update on `mdx.jsx` and `Layout.jsx` to make dates sticky on `XL` resolutions to improve user navigation, showing news boundaries between dates

https://github.com/midudev/noticias.dev/assets/6987914/e157bf5e-ee17-483c-a750-57af18424856


