### PR TITLE
Change absolute className by fixed in Timeline component

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -7,7 +7,7 @@ function Timeline() {
   let id = useId()
 
   return (
-    <div className="pointer-events-none absolute inset-0 z-50 overflow-hidden lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] lg:overflow-visible">
+    <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden lg:right-[calc(max(2rem,50%-38rem)+40rem)] lg:min-w-[32rem] lg:overflow-visible">
       <svg
         className="absolute left-[max(0px,calc(50%-18.125rem))] top-0 h-full w-1.5 lg:left-full lg:ml-1 xl:left-auto xl:right-1 xl:ml-0"
         aria-hidden="true"


### PR DESCRIPTION
This PR changes the className of the Timeline component so that when scrolling it always shows.